### PR TITLE
Fixed build error and some templating issues

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,12 +5,15 @@
   "author": "Daniel G. Taylor",
   "license": "MIT",
   "dependencies": {
-    "wintersmith-coffee": "~0.2.0",
-    "wintersmith-stylus": "~0.4.0",
-    "moment": "~2.1.0",
-    "i18n": "~0.4.1",
-    "wintersmith": "~2.0.5",
-    "async": "~0.2.9",
-    "slugg": "~0.1.2"
+    "async": "~3.2.0",
+    "i18n": "~0.9.0",
+    "moment": "~2.25.0",
+    "nunjucks": "^3.2.1",
+    "slugg": "~1.2.1",
+    "wintersmith-coffee": "~0.2.2",
+    "wintersmith-stylus": "~0.5.1"
+  },
+  "scripts": {
+    "ws": "wintersmith"
   }
 }

--- a/web/plugins/nunjucks.coffee
+++ b/web/plugins/nunjucks.coffee
@@ -118,6 +118,7 @@ module.exports = (env, done) ->
     class MdTag
         # The tag name
         tags: ['md']
+        autoescape: false
 
         # What to do when the tag is encountered
         parse: (parser, nodes, lexer) ->
@@ -140,9 +141,7 @@ module.exports = (env, done) ->
             tmpl = new Template templateStr, nenv, locals.page.filepath.full
             rendered = tmpl.render locals
 
-            # Set the new markdown content and render to HTML
-            locals.page.markdown = rendered
-            return locals.page.getHtml()
+            return rendered
 
     nenv.addExtension 'MdTag', new MdTag()
 
@@ -235,7 +234,7 @@ module.exports = (env, done) ->
 
             genLangPage = (filepath, done) ->
                 name = filepath.relative
-                page = MarkdownPage.fromFile full: filepath.full, (err, page) ->
+                page = MarkdownPage.fromFile filepath, (err, page) ->
                     page.metadata.filename = "#{env.utils.stripExtension(name)}-#{lang}.html"
                     page.metadata.template = "#{page.metadata.template}-de"
                     rv["#{name}-#{lang}"] = page


### PR DESCRIPTION
Pulling directly from the repo and building as instructed produced build errors, something about relative path being undefined instead of a string.

Additionally, nunjunk was updated which appears to have turned on autoescape for custom tags; this is now turned off for the md tag

Not sure why there's HTML in the `.md` files but it's was being passed through a markdown processor and converted to pre/code tags; that processing step has been removed.

Bumped the deps